### PR TITLE
Fix a typo in the ip address

### DIFF
--- a/before-you-start/deploying-from-dockerhub.md
+++ b/before-you-start/deploying-from-dockerhub.md
@@ -7,7 +7,7 @@ For using these container images, ensure you have a recent version of `docker` i
 To try `grimoirelab/full`, just type:
 
 ```bash
-$ docker run -p 127:0.0.1:5601:5601 \
+$ docker run -p 127.0.0.1:5601:5601 \
     -v $(pwd)/mordred-local.cfg:/mordred-local.cfg \
     -t grimoirelab/full
 ```


### PR DESCRIPTION
docker: Invalid ip address 127:0.0.1: address 127:0.0.1:: too many colons in address.