### PR TITLE
perceval_gerrit: replace url by hostname

### DIFF
--- a/perceval/scripts/perceval_gerrit_1.py
+++ b/perceval/scripts/perceval_gerrit_1.py
@@ -1,17 +1,16 @@
 #! /usr/bin/env python3
 
 from datetime import datetime, timedelta
-
 from perceval.backends.core.gerrit import Gerrit
 
 # hostname of the Gerrit instance
 hostname = 'gerrit.opnfv.org'
 # user for sshing to the Gerrit instance
 user = 'jgbarah'
-# retrieve only reviews changed since this date
+# retrieve only reviews changed since one day ago
 from_date = datetime.now() - timedelta(days=1)
 # create a Gerrit object, pointing to hostname, using user for ssh access
-repo = Gerrit(url=hostname, user=user)
+repo = Gerrit(hostname=hostname, user=user)
 
 # fetch all reviews as an iterator, and iterate it printing each review id
 for review in repo.fetch(from_date=from_date):

--- a/perceval/scripts/perceval_gerrit_2.py
+++ b/perceval/scripts/perceval_gerrit_2.py
@@ -11,7 +11,7 @@ user = 'jgbarah'
 # retrieve only reviews changed since this date
 from_date = datetime.datetime.now() - datetime.timedelta(days=1)
 # create a Gerrit object, pointing to hostname, using user for ssh access
-repo = Gerrit(url=hostname, user=user)
+repo = Gerrit(hostname=hostname, user=user)
 
 # fetch all reviews as an iterator, and iterate it printing each review id
 for review in repo.fetch(from_date=from_date):


### PR DESCRIPTION
In the current version you obtain a bug in perceval_gerrit_1.py and perceval_gerrit_2.py:
$ python3 perceval_gerrit_1.py 
Traceb:ack (most recent call last):
  File "perceval_gerrit_1.py", line 13, in <module>
    repo = Gerrit(url=hostname, user=user)
TypeError: __init__() got an unexpected keyword argument 'url'

This error is fixed replacing url by hostname.