### PR TITLE
Fix inconsistency between perceval tutorial and code

### DIFF
--- a/perceval/github.md
+++ b/perceval/github.md
@@ -180,7 +180,7 @@ Instead of "XXXXX" use your own GitHub token. You can obtain tokens via the GitH
 * Once in "Personal access tokens", click on "Generate new token" \(top right\).
 * Once in "New personal access token", select a name for your token \("token desription"\), and select the scopes for it. If you're going to use it only with perceval, you don't really need permissions for any scope, so you don't need to select any.
 
-Whichever the authentication method, perceval produces, as it did for the git backend, a JSON document for each item in stdout, and some messages in stderr. You can see both differentiated, for example, by redirecting stdout to a file:
+Regardless of the method used, perceval produces (as it did for the git backend) a JSON document for each item in stdout, and some messages in stderr. You can see both differentiated, for example, by redirecting stdout to a file:
 
 ```
 (perceval) $ perceval github grimoirelab perceval --sleep-for-rate \

--- a/perceval/github.md
+++ b/perceval/github.md
@@ -166,16 +166,7 @@ As the message itself states, you can avoid this rate limit by using authenticat
 
 ## Retrieving from GitHub with authentication
 
-To avoid the problems with the unauthenticated access to the GitHub API, we can use the Perceval GitHub backend with authentication:
-
-```bash
-(perceval) $ perceval github grimoirelab perceval --sleep-for-rate \
-    -u jgbarah -p XXX
-```
-
-Instead of "jgbarah",use your own GitHub username, and instead of XXX your GitHub password. This will only work if you didn't set up [two factor authentication for GitHub](https://help.github.com/articles/about-two-factor-authentication/). If you did, you can still use the following method \(which you can use as well if you didn't set up it\).
-
-Alternatively, you can use GitHub user tokens as well:
+To avoid the problems due to unauthenticated access to the GitHub API, we can use the Perceval GitHub backend with authentication using Github tokens:
 
 ```bash
 (perceval) $ perceval github grimoirelab perceval --sleep-for-rate \

--- a/perceval/github.md
+++ b/perceval/github.md
@@ -6,17 +6,17 @@
 
 To begin with, let's get some help from our friend:
 
-```bash
+```bash 
 (perceval) $ perceval github --help
 ...
 ```
 
-In that help banner, we see three different ways of using it:
+In that help banner, we see two different ways of using it:
 
 * with no credentials
-* with a user and password
 * with a user token
 
+## Retrieving from GitHub with no credentials
 If you use the GitHub Perceval backend with no credentials, you'll have basic access to the GitHub API. The main difference with using authenticated use is the rate limit: a much more stringent rate limit \(number of requests to the GitHub API\) will be applied by GitHub. In any case, this basic access is very simple, since it requires no user, password or token. For example, for accessing tickets and pull requests in the Perceval repository:
 
 ```bash


### PR DESCRIPTION
As discussed with @valeriocos in [the issue linked here](https://github.com/chaoss/grimoirelab-perceval/issues/483), this pull request updates the part of the tutorial which specifies a non-existing method of authentication --- using username and password.