### PR TITLE
Add missing --cfg flag to example micro-mordred command

### DIFF
--- a/sirmordred/micro-mordred.md
+++ b/sirmordred/micro-mordred.md
@@ -99,7 +99,7 @@ kibiter_1        | {"type":"log","@timestamp":"2019-05-30T09:38:25Z","tags":["st
 3. As you can see on the `Kibiter Instance` above, it says `Couldn't find any Elasticsearch data. You'll need to index some data into Elasticsearch before you can create an index pattern`. Hence, in order to index some data, we'll now execute micro-mordred using the following command, which will call the `Raw` and `Enrich` tasks for the Git config section from the provided `setup.cfg` file.
 
 ```
-$ python3 micro.py --raw --enrich setup.cfg --backends git
+$ python3 micro.py --raw --enrich --cfg setup.cfg --backends git
 ```
 
 The above command requires two files:


### PR DESCRIPTION
The [micro-mordred example](https://chaoss.github.io/grimoirelab-tutorial/sirmordred/micro-mordred.html) includes a command that the user is expected to execute but which is missing the `--cfg` flag.  Without this, they get the following error:

```
usage: micro.py [--arthur] [--raw] [--enrich] [--identities-load]
                [--identities-merge] [--panels] [--cfg CFG_PATH]
                [--backends [BACKEND_SECTIONS [BACKEND_SECTIONS ...]]]
micro.py: error: unrecognized arguments: setup.cfg
```

This PR adds the missing flag.