### PR TITLE
Clarity on Elasticsearch requirement

### DIFF
--- a/basics/supporting.md
+++ b/basics/supporting.md
@@ -64,7 +64,7 @@ More information about installing git in other platforms is available in
 
 ### Installing ElasticSearch
 
-In case you decide to install ElasticSearch and Kibiter or Kibana yourself, instead of using them as a service, the process is not difficult. Please ensure you're installing at least version 5.1 of both of them. As a rule, versions for Kibana and ElasticSearch should be the same if they are to work together. If you are installing Kibiter, you can find out the latest release of it (see below), and install the corresponding ElasticSearch version.
+If you do not already have an instance of ElasticSearch and Kibiter or Kibana that you will be using, you will need to manually install them.  They are not installed as part of the automated installation. The process is not difficult. Please ensure you're installing at least version 5.1 of both of them. As a rule, versions for Kibana and ElasticSearch should be the same if they are to work together. If you are installing Kibiter, you can find out the latest release of it (see below), and install the corresponding ElasticSearch version.
 
 For installing ElasticSearch you can follow its [installation instructions](https://www.elastic.co/guide/en/elasticsearch/reference/current/install-elasticsearch.html). You will need to have a Java virtual machine installed \(Oracle JDK version 1.8.x is recommended\), The rest is simple: download the installation file from the [ElasticSearch downloads area](https://www.elastic.co/downloads/elasticsearch), and install it, for example by unzipping the zip installation file.
 


### PR DESCRIPTION
As a new user and a technical end-user rather than a developer, these instructions were unclear to me that Elasticsearch was not being installed as part of the installation process. Made a small suggestion for making this explicitly clear based on my understanding of the situation.

Signed-off-by: Ruth Cheesley <ruth.cheesley@acquia.com>