### PR TITLE
Removes duplication from the sidebar

### DIFF
--- a/_data/sidebars/home_sidebar.yml
+++ b/_data/sidebars/home_sidebar.yml
@@ -9,12 +9,8 @@ entries:
     output: web
     folderitems:
 
-    - title: Presentation
-      url: /
-      output: web
-
     - title: Introduction
-      url: /README.html
+      url: /
       output: web
       subfolders:
 


### PR DESCRIPTION
The Presentation page contains the same content as the
Introduction page, hereby causing unnecessary duplication.
This commit corrects that by removing the Presentation page
from the sidebar.

References: #134