### PR TITLE
Removed Link of OPNFV Development Dashboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ With the tools in the GrimoireLab toolset you can retrieve data, store it in dat
 
 ![](eclipse.png)
 
-Example dashboard produced with GrimoireLab: the [OPNFV Development Dashboard](http://opnfv.biterg.io)
+Example dashboard produced with GrimoireLab: the [OPNFV Development Dashboard]
 
 ## Quick overview
 


### PR DESCRIPTION
Signed-off-by: Sourabh Saraswat 191939

Removed Link of OPNFV Development Dashboard, which is not working and showing message Decommissioned dashboard! .