### PR TITLE
[docs] Add information for using private git repos

### DIFF
--- a/docs/data-sources/configurations.md
+++ b/docs/data-sources/configurations.md
@@ -373,6 +373,8 @@ author_field = author_uuid
 
 Commits from Git
 
+**Note:** If you want to analyze private git repositories, make sure you pass the credentials directly in the URL.
+
 - projects.json
 
 ```
@@ -380,7 +382,7 @@ Commits from Git
     "Chaoss": {
         "git": [
             "https:/github.com/chaoss/grimoirelab-perceval",
-            "https:/github.com/chaoss/grimoirelab-sirmordred"
+            "https://<username>:<api-token>@github.com/chaoss/grimoirelab-sirmordred"
         ]
     }
 }


### PR DESCRIPTION
This commit adds documentation for using grimoirelab against
private git repositories. The configurations.md is updated
with an example.

Signed-off-by: Jorge García Rey <jorgegar@inditex.com>