### PR TITLE
Update _config.yml

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -3,6 +3,7 @@ description: >-
   GrimoireLab Tutorial
 permalink: pretty
 markdown: kramdown
+baseurl: "/grimoirelab-tutorial"
 
 kramdown:
   toc_levels: 2..3
@@ -19,7 +20,10 @@ exclude:
 # JUST THE DOCS CONFIG
 theme: "just-the-docs"
 remote_theme: pmarsceill/just-the-docs
-#color_scheme: "dark"
+# color_scheme: "dark"
+
+# Set a path/url to a logo that will be displayed instead of the title
+logo: "assets/grimoirelab.png"
 
 # Enable or disable the site search
 # Supports true (default) or false
@@ -38,6 +42,9 @@ aux_links:
     - "//lists.linuxfoundation.org/mailman/listinfo/grimoirelab-discussions"
   "Slack":
     - "//chaoss-workspace.slack.com/archives/C022NPTPC8Z"
+
+# Makes Aux links open in a new tab. Default is false
+aux_links_new_tab: true
 
 # Heading anchor links appear on hover over h1-h6 tags in page content
 # allowing users to deep link to a particular heading on a page.

--- a/index.md
+++ b/index.md
@@ -5,7 +5,7 @@ nav_order: 1
 permalink: /
 ---
 
-# About GrimoireLab
+![](./assets/grimoirelab-logo.png)
 
 GrimoireLab is a [CHAOSS](https://chaoss.community) toolset for software
 development analytics. It includes a coordinated set of tools to retrieve data
@@ -34,8 +34,9 @@ Gerrit, Launchpad, Jira, mailing lists, Confluence, Discourse, Slack, Jenkins,
 Meetup, Mediawiki, Phabricator, Redmine, StackOverflow, Telegram, and others.
 
 Let´s now visit the main functionalities provided by GrimoireLab. The section
-[Components](/components) shows how the different components in GrimoireLab are
-combined to provide these functionalities.
+[Components]({{ site.baseurl }}{% link docs/components/components.md %}) shows
+how the different components in GrimoireLab are combined to provide these
+functionalities.
 
 ### Data retrieval
 


### PR DESCRIPTION
This PR adds some configurations to the _config.yml file to include some of the features of just-the-docs theme. It also adds the basepath field to fix the broken links issue and adds the grimoirelab logo to the homepage.