### PR TITLE
[config] Updated the link in the footer to master

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -63,7 +63,7 @@ footer_content: 'Copyright &copy CHAOSS; 2017-2021. <br>Distributed by an <a hre
 gh_edit_link: true # show or hide edit this page link
 gh_edit_link_text: "Edit this page on GitHub"
 gh_edit_repository: "https://github.com/chaoss/grimoirelab-tutorial" # the github URL for your repo
-gh_edit_branch: "tesseract" # the branch that your docs is served from
+gh_edit_branch: "master" # the branch that your docs is served from
 # gh_edit_source: docs # the source that your files originate from
 gh_edit_view_mode: "tree" # "tree" or "edit" if you want the user to jump into the editor immediately
 


### PR DESCRIPTION
Fixes #195

There was an issue with the [_config.yml](https://github.com/chaoss/grimoirelab-tutorial/blob/master/_config.yml) file that was generating a link to the [tesseract](https://github.com/chaoss/grimoirelab-tutorial/tree/tesseract) branch instead of the intended [master](https://github.com/chaoss/grimoirelab-tutorial/tree/master) branch.