### PR TITLE
Bump dependencies versions

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,3 +5,5 @@ gem 'github-pages', group: :jekyll_plugins
 gem "just-the-docs"
 
 gem 'jekyll-redirect-from'
+
+gem "webrick", "~> 1.8"


### PR DESCRIPTION
Versions bumped automatically with `bundle update`.
webrick was added to support Jekyll versions 3.0.0 or later.